### PR TITLE
WIP Added support for self signed SSL certs in local env

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const fetch = require('isomorphic-fetch');
+const https = require("https");
 
 class RPCClient {
   constructor(options = {}) {
@@ -11,7 +12,7 @@ class RPCClient {
   }
 
   call(name, args) {
-    return fetch(this.url, {
+    const options = {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -22,7 +23,13 @@ class RPCClient {
         args: JSON.stringify(args),
       }),
       credentials: this.sendCredentials,
-    })
+    }
+    if (process.env.NODE_ENV !== 'production') {
+      options.agent = new https.Agent({
+        rejectUnauthorized: false
+      });
+    }
+    return fetch(this.url, options)
       .then(
         response =>
           new Promise((resolve, reject) => {


### PR DESCRIPTION
Proposed change by @kiriappeee to solve some issues when working on the Zendesk App (cc @mickmahady)

> When running the Micro RPC client against URL's in the local
> environment we need to support ignoring SSL cert errors. This commit
> achieves that by searching for NODE_ENV=production. If it does not
> find it, it adds an https agent to ignore the SSL cert error